### PR TITLE
Alter API routes to avoid the use of /api/

### DIFF
--- a/src/main/java/org/traccar/database/OpenIdProvider.java
+++ b/src/main/java/org/traccar/database/OpenIdProvider.java
@@ -87,7 +87,7 @@ public class OpenIdProvider {
         clientAuth = new ClientSecretBasic(clientId, new Secret(config.getString(Keys.OPENID_CLIENT_SECRET)));
 
         baseUrl = new URI(WebHelper.retrieveWebUrl(config));
-        callbackUrl = new URI(WebHelper.retrieveWebUrl(config) + "/api/session/openid/callback");
+        callbackUrl = new URI(WebHelper.retrieveWebUrl(config) + "/ct-api/session/openid/callback");
 
         if (config.hasKey(Keys.OPENID_ISSUER_URL)) {
             HttpRequest httpRequest = HttpRequest.newBuilder(

--- a/src/main/java/org/traccar/web/WebServer.java
+++ b/src/main/java/org/traccar/web/WebServer.java
@@ -151,7 +151,7 @@ public class WebServer implements LifecycleObject {
             }
             servletHandler.setWelcomeFiles(new String[] {"release.html", "index.html"});
         }
-        servletHandler.addServlet(servletHolder, "/*");
+        servletHandler.addServlet(servletHolder, "/ct/*");
     }
 
     private void initApi(ServletContextHandler servletHandler) {

--- a/templates/full/media.vm
+++ b/templates/full/media.vm
@@ -4,7 +4,7 @@
 <body>
 Device: $device.name<br>
 Type: $event.getString("media")<br>
-File: <a href="$webUrl/api/media/$device.uniqueId/$event.getString("file")">$event.getString("file")</a><br>
+File: <a href="$webUrl/ct-api/media/$device.uniqueId/$event.getString("file")">$event.getString("file")</a><br>
 Time: $dateTool.format("YYYY-MM-dd HH:mm:ss", $event.eventTime, $locale, $timezone)<br>
 Link: <a href="$webUrl?eventId=$event.id">$webUrl?eventId=$event.id</a><br>
 <br>


### PR DESCRIPTION
I am altering the backend source code. After changing the /api/ to /ct-api/ on the Nginx proxy, there were problems with files and callbacks of Oauth2 authentication. The below changes fix the issues.